### PR TITLE
Prefer SNDHWM and RCVHWM to HWM

### DIFF
--- a/colmet/common/backends/zeromq.py
+++ b/colmet/common/backends/zeromq.py
@@ -14,11 +14,11 @@ from colmet.common.metrics.base import BaseCounters
 from colmet.common.backends.base import InputBaseBackend, OutputBaseBackend
 
 try:
-    _snd_hwm = zmq.HWM
-    _rcv_hwm = zmq.HWM
-except AttributeError:
     _snd_hwm = zmq.SNDHWM
     _rcv_hwm = zmq.RCVHWM
+except AttributeError:
+    _snd_hwm = zmq.HWM
+    _rcv_hwm = zmq.HWM
 
 
 class ZMQInputBackend(InputBaseBackend):


### PR DESCRIPTION
Calling `socket.setsockopt(zmq.HWM, value)` crashes with the `Invalid argument error` [since libzmq 3.0.0](https://github.com/zeromq/pyzmq/issues/1831#issuecomment-1408661423), which was [released 13 years ago](https://github.com/zeromq/libzmq/commit/dee5f650dde07ec71f482e825984a31028467d1b).

The `HWM` constant was removed in the C library but is still present in the Python bindings for some reason. Thus, no `AttributeError` was thrown when defining `_snd_hwm` and `_rcv_hwm` and the code was crashing later on (line 73 in the same file).

This patch uses the new symbols by default, and fallbacks to the old one if they are not defined. It fixes the issue, while keeping compatibility with old versions.